### PR TITLE
Added a context-menu icon for running the bigquery-preview command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"commands": [
 			{
 				"command": "dbt-bigquery-preview.preview",
-				"title": "dbt-bigquery-preview: Preview dbt results"
+				"title": "dbt-bigquery-preview: Preview dbt results",
+				"icon": "$(open-preview)"
 			}
 		],
 		"configuration": {
@@ -47,6 +48,15 @@
 					"description": "Points to the dbt executable."
 				}
 			}
+		},
+		"menus": {
+		  "editor/title": [
+			{
+			  "when": "resourceLangId == sql || resourceLangId == jinja-sql",
+			  "command": "dbt-bigquery-preview.preview",
+			  "group": "navigation"
+			}
+		  ]
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
As the title describes. Following the vscode extension guidelines; I reused an existing icon called `open-preview` I think this fits the bill nicely.

![image](https://user-images.githubusercontent.com/6634187/189640140-2470eebb-5083-4deb-b4a1-9a4c01dd74cc.png)
